### PR TITLE
Add employee recognition module

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Initially, it was a set of modules within ERPNext but version 14 onwards, as the
 - **Performance Management**: Track goals, align goals with key result areas (KRAs), enable employees to evaluate themselves, make managing appraisal cycles easy.
 - **Payroll & Taxation**: Create salary structures, configure income tax slabs, run standard payroll, accomodate additional salaries and off cycle payments, view income breakup on salary slips and so much more.
 - **Frappe HR Mobile App**: Apply for and approve leaves on the go, check-in and check-out, access employee profile right from the mobile app.
+- **Employee Recognition**: Let peers award points or badges for accomplishments and redeem them for rewards.
 
 <details open>
 

--- a/hrms/hr/doctype/employee_recognition/README.md
+++ b/hrms/hr/doctype/employee_recognition/README.md
@@ -1,0 +1,3 @@
+# Employee Recognition
+
+This module lets employees recognize their peers for accomplishments. Recognitions can grant points or badges that can later be redeemed for rewards.

--- a/hrms/hr/doctype/employee_recognition/__init__.py
+++ b/hrms/hr/doctype/employee_recognition/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd.
+# For license information, please see license.txt
+
+from .employee_recognition import EmployeeRecognition

--- a/hrms/hr/doctype/employee_recognition/employee_recognition.json
+++ b/hrms/hr/doctype/employee_recognition/employee_recognition.json
@@ -1,0 +1,16 @@
+{
+ "doctype": "DocType",
+ "name": "Employee Recognition",
+ "module": "HR",
+ "custom": 0,
+ "fields": [
+  {"fieldname": "awarding_employee", "fieldtype": "Link", "options": "Employee", "label": "Awarding Employee"},
+  {"fieldname": "recognized_employee", "fieldtype": "Link", "options": "Employee", "label": "Recognized Employee"},
+  {"fieldname": "points", "fieldtype": "Int", "label": "Points"},
+  {"fieldname": "badge", "fieldtype": "Data", "label": "Badge"},
+  {"fieldname": "notes", "fieldtype": "Small Text", "label": "Notes"}
+ ],
+ "permissions": [
+  {"role": "Employee", "read": 1, "write": 1, "create": 1}
+ ]
+}

--- a/hrms/hr/doctype/employee_recognition/employee_recognition.py
+++ b/hrms/hr/doctype/employee_recognition/employee_recognition.py
@@ -1,0 +1,23 @@
+import frappe
+from frappe.model.document import Document
+
+class EmployeeRecognition(Document):
+    """Record of peer-to-peer recognition."""
+
+    def validate(self):
+        self.award_points()
+
+    def award_points(self):
+        if not self.points:
+            return
+        employee = frappe.get_doc("Employee", self.recognized_employee)
+        current_points = employee.get("recognition_points") or 0
+        employee.db_set("recognition_points", current_points + self.points)
+
+    def redeem(self, reward, points_required):
+        employee = frappe.get_doc("Employee", self.recognized_employee)
+        current_points = employee.get("recognition_points") or 0
+        if current_points < points_required:
+            frappe.throw("Not enough recognition points")
+        employee.db_set("recognition_points", current_points - points_required)
+        frappe.msgprint(f"Redeemed {reward} for {points_required} points")

--- a/hrms/hr/doctype/employee_recognition/test_employee_recognition.py
+++ b/hrms/hr/doctype/employee_recognition/test_employee_recognition.py
@@ -1,0 +1,22 @@
+import frappe
+from hrms.hr.doctype.employee_recognition.employee_recognition import EmployeeRecognition
+
+
+def test_award_points(monkeypatch):
+    emp = frappe._dict(name="EMP-0001", recognition_points=0)
+
+    def fake_get_doc(dt, name):
+        assert dt == "Employee"
+        return emp
+
+    monkeypatch.setattr(frappe, "get_doc", fake_get_doc)
+
+    doc = EmployeeRecognition(
+        awarding_employee="EMP-0002",
+        recognized_employee="EMP-0001",
+        points=10,
+    )
+
+    monkeypatch.setattr(emp, "db_set", lambda field, val: emp.update({field: val}))
+    doc.validate()
+    assert emp.recognition_points == 10

--- a/hrms/modules.txt
+++ b/hrms/modules.txt
@@ -1,2 +1,3 @@
 HR
 Payroll
+Employee Recognition


### PR DESCRIPTION
## Summary
- add Employee Recognition as a new HRMS module
- document employee recognition in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_688702170188832b87ea5e5346518c44